### PR TITLE
Change django.contrib.contenttypes.generic imports

### DIFF
--- a/graphviz/management/commands/modelviz.py
+++ b/graphviz/management/commands/modelviz.py
@@ -12,8 +12,9 @@ from django.db.models.fields.related import \
 from django.core.management.base import AppCommand
 
 try:
-    from django.db.models.fields.generic import GenericRelation
+    from django.contrib.contenttypes.fields import GenericRelation
 except ImportError:
+    # Django < 1.7 support
     from django.contrib.contenttypes.generic import GenericRelation
 
 head_template = """

--- a/graphviz/models.py
+++ b/graphviz/models.py
@@ -1,6 +1,10 @@
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    # Django < 1.7 support
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 class Graph(models.Model):
     """ the object defined by the generic relation should have
@@ -24,7 +28,7 @@ class Graph(models.Model):
     name = models.CharField(max_length=50)
     content_type = models.ForeignKey(ContentType, null=True, blank=True)
     object_id = models.PositiveIntegerField(null=True, blank=True)
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
     
     def view_dot_file(self):
         if not self.object_id: return "(n.a.)"


### PR DESCRIPTION
django.contrib.contenttypes.generic is deprecated in django 1.7.
GenericRelation and GenericForeignKey should now be imported from
django.contrib.contenttypes.fields
